### PR TITLE
Fix dropped tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avatarapi"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cargo run
 
 ### ❖ What's New?
 
-0.4.0 - Use in-memory sqlite
+0.4.1 - Fix using in-memory sqlite
 
 ---
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use csv::ReaderBuilder;
 use serde::{Deserialize, Serialize};
-use sqlx::sqlite::SqlitePool;
+use sqlx::sqlite::{SqlitePoolOptions, SqlitePool};
 use sqlx::Row;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -30,7 +30,11 @@ pub enum Column {
 
 impl Database {
     pub async fn new(path: &str) -> Result<Self> {
-        let pool = SqlitePool::connect("sqlite::memory:").await?;
+        let pool = SqlitePoolOptions::new()
+            .max_lifetime(None)
+            .idle_timeout(None)
+            .connect("sqlite::memory:")
+            .await?;
         let mut rdr = ReaderBuilder::new().delimiter(b'|').from_path(path)?;
         sqlx::query(
             r#"CREATE TABLE quotes(


### PR DESCRIPTION
## Overview

Switching to in memory DB causes the table to get dropped after a little bit, this PR addresses that issue by adjusting the lifetime.

closes https://github.com/dotzenith/AvatarSay/issues/1